### PR TITLE
Remove `q` requirement in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Users get kicked after 2 minutes of not entering a valid move
 
 ## Chat Commands!
 
-- `!joinq` or `!jq`
-- `!leaveq` or `!lq`
+- `!join` or `!j`
+- `!leave` or `!l`
 - `!queue` or `!q`
 - `scramble` completes a random scramble on the puzzle
 - `scramble <alg>` set a custom scramble. 

--- a/client/TSC.ts
+++ b/client/TSC.ts
@@ -41,7 +41,7 @@ export default class TSC {
         this.enqueue(username);
         //isFollowing(username);
         this.userTurnTime();
-        this.send(`@${username}, it's your turn! Do !leaveQ when done`);
+        this.send(`@${username}, it's your turn! Do !leave when done`);
         //response = await this.kickAFK(); //TODO: Response
       } else if (this.getCurrentUser() === username) {
         this.send(`@${username}, it's currently your turn!`);
@@ -52,7 +52,7 @@ export default class TSC {
         this.send(`@${username}, you're already in the queue. Please wait :)`);
       }
     } else {
-       this.send("The cube is currently in Vote mode. No need to !joinq, just type a move in chat");
+       this.send("The cube is currently in Vote mode. No need to !join, just type a move in chat");
     }
 
     //console.log('[' + this.getCurrentDate().toLocaleTimeString() + '] ' + response); //TODO: Add timestamps to console logs
@@ -75,20 +75,20 @@ export default class TSC {
         if (currentUser && !chatRemoval) { // If the user is removed by the timer queue next player
           //isFollowing(currentUser);
           this.userTurnTime();
-          this.send(`@${currentUser}, it's your turn! Do !leaveQ when done. `);
+          this.send(`@${currentUser}, it's your turn! Do !leave when done. `);
           //this.kickAFK();
         } else if (this.queue.length === 0) { //If there is no user left in the queue
           //Restarts and clears the bottom timer, response gets sent before the person leaves the queue
           this.clearUserTurnTimer();
           this.setUserLabel("");
-          this.send(`The queue is currently empty. Anyone is free to !joinQ. `);
+          this.send(`The queue is currently empty. Anyone is free to !join. `);
         }
         this.send(`@${username}, you have been removed from the queue. `);
       } else {
-          this.send(`@${username}, you are not in the queue. Type !joinQ to join. `);
+          this.send(`@${username}, you are not in the queue. Type !join to join. `);
       }
     } else {
-        this.send(`The cube is currently in Vote mode. No need to !leaveq, just type a move in chat. `);
+        this.send(`The cube is currently in Vote mode. No need to !leave, just type a move in chat. `);
     }
   
     //console.log('[' + this.getCurrentDate().toLocaleTimeString() + '] ' + responses.join('\n'));

--- a/client/cube.ts
+++ b/client/cube.ts
@@ -224,16 +224,19 @@ export default class tscCube {
   async handleMessage(user: string, move: string, message: string, isFollower: boolean, isSub: boolean, isMod: boolean) {
     const queue = this.tsc.getQueue();
     let currentUser = this.tsc.getCurrentUser();
+
+    const joinCommands = ["!join", "!j", "!joinq", "!jq"];
+    const leaveCommands = ["!leave", "!l", "!leaveq", "!lq"];
   
     if (message === "!queue" || message === "!q") {
       if (queue.length > 0) {
         this.send(`${queue}`);
       } else {
-        this.send("There's currently no one in the queue, do !joinq");
+        this.send("There's currently no one in the queue, do !join");
       }
-    } else if (message.startsWith("!joinq") || message.startsWith("!jq")) {
+    } else if (joinCommands.includes(message)) {
       await this.tsc.joinQueue(user);
-    } else if (message === "!leaveq" || message === "!lq") {
+    } else if (leaveCommands.includes(message)) {
       await this.tsc.removePlayer(user, true);
     } else if ((message.startsWith("!remove") || message.startsWith("!rm")) && isMod) {
       const userToRemove = message!.split(' ').pop()?.split('@').pop()!;


### PR DESCRIPTION
I still need to test this, and will need to update the stream bot commands to align with this change.

It seems that some new users get confused with `!joinq` and try to use `!joinq`. This PR still supports `!joinq` for older users.